### PR TITLE
Changed Typescript exercises link

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Codepens and exercises are related to these three VueMastery courses that you ne
 
 Follow the course [TypeScript: Getting Started](https://app.pluralsight.com/library/courses/getting-started-typescript/table-of-contents)
 
-[Exercises](https://app.pluralsight.com/library/courses/typescript-getting-started/exercise-files)
+[Exercises](https://app.pluralsight.com/library/courses/getting-started-typescript/exercise-files)
 
 ## Git
 


### PR DESCRIPTION
The exercises link was pointing to the old version of the course while the course link refers to newer version